### PR TITLE
make shoco compile without error on gcc

### DIFF
--- a/shoco.h
+++ b/shoco.h
@@ -4,6 +4,8 @@
 
 #if defined(_MSC_VER)
 #define shoco_restrict __restrict
+#elif __GNUC__
+#define shoco_restrict __restrict__
 #else
 #define shoco_restrict restrict
 #endif


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Restricted-Pointers.html
Tested with gcc 4.9.2.
