### PR TITLE
Prevent buffer overflows in decompression

### DIFF
--- a/shoco.c
+++ b/shoco.c
@@ -179,13 +179,17 @@ size_t shoco_decompress(const char * const shoco_restrict original, size_t compl
         return bufsize + 1;
 
       // ignore the sentinel value for non-ascii chars
-      if (*in == 0x00)
-        ++in;
+      if (*in == 0x00) {
+        if (++in >= in_end)
+          return SIZE_MAX;
+      }
 
       *o++ = *in++;
     } else {
       if (o + packs[mark].bytes_unpacked > out_end)
         return bufsize + 1;
+      else if (in + packs[mark].bytes_packed > in_end)
+        return SIZE_MAX;
 
       // This should be OK as well, but it fails with emscripten.
       // Test this with new versions of emcc.

--- a/tests.c
+++ b/tests.c
@@ -1,3 +1,4 @@
+#include "stdint.h"
 #include "stdio.h"
 #include "assert.h"
 #include "string.h"
@@ -12,7 +13,7 @@ int main() {
   char buf_2[2];
   char buf_4[4];
   char buf_large[4096];
-  int ret;
+  size_t ret;
 
   // test compression
   ret = shoco_compress(LARGE_STR, 0, buf_2, 2);
@@ -92,6 +93,12 @@ int main() {
   assert(ret == non_ascii_len);
   assert(strcmp(buf_large, NON_ASCII_STR) == 0);
   assert(buf_large[non_ascii_len] == '\0'); // null byte written
+
+  ret = shoco_decompress("\x00", 1, buf_large, 4096);
+  assert(ret == SIZE_MAX);
+
+  ret = shoco_decompress("\xe0""ab", 3, buf_large, 4096);
+  assert(ret == SIZE_MAX);
 
   puts("All tests passed.");
   return 0;


### PR DESCRIPTION
shoco_decompress prevents buffer overflows by returning SIZE_MAX when
the input is smaller than expected.

This commit fixes #12 