### PR TITLE
use unsigned for byte-buffer

### DIFF
--- a/generate_compressor_model.py
+++ b/generate_compressor_model.py
@@ -51,8 +51,8 @@ typedef struct Pack {{
   const unsigned int bytes_unpacked;
   const unsigned int offsets[{max_elements_len}];
   const int16_t _ALIGNED masks[{max_elements_len}];
-  const char header_mask;
-  const char header;
+  const unsigned char header_mask;
+  const unsigned char header;
 }} Pack;
 
 #ifdef _MSC_VER

--- a/models/dictionary.h
+++ b/models/dictionary.h
@@ -92,8 +92,8 @@ typedef struct Pack {
   unsigned int n_successors;
   unsigned const int offsets[8];
   const int masks[8];
-  char header_mask;
-  char header;
+  unsigned char header_mask;
+  unsigned char header;
 } Pack;
 
 #define PACK_COUNT 3

--- a/models/filepaths.h
+++ b/models/filepaths.h
@@ -141,8 +141,8 @@ typedef struct Pack {
   const unsigned int bytes_unpacked;
   const unsigned int offsets[8];
   const int16_t _ALIGNED masks[8];
-  const char header_mask;
-  const char header;
+  const unsigned char header_mask;
+  const unsigned char header;
 } Pack;
 
 #define PACK_COUNT 3

--- a/models/text_en.h
+++ b/models/text_en.h
@@ -155,8 +155,8 @@ typedef struct Pack {
   const unsigned int bytes_unpacked;
   const unsigned int offsets[8];
   const int16_t _ALIGNED masks[8];
-  const char header_mask;
-  const char header;
+  const unsigned char header_mask;
+  const unsigned char header;
 } Pack;
 
 #define PACK_COUNT 3

--- a/shoco_model.h
+++ b/shoco_model.h
@@ -148,8 +148,8 @@ typedef struct Pack {
   const unsigned int bytes_unpacked;
   const unsigned int offsets[8];
   const int16_t _ALIGNED masks[8];
-  const char header_mask;
-  const char header;
+  const unsigned char header_mask;
+  const unsigned char header;
 } Pack;
 
 #define PACK_COUNT 3

--- a/shoco_table.h
+++ b/shoco_table.h
@@ -148,8 +148,8 @@ typedef struct Pack {
   const unsigned int bytes_unpacked;
   const unsigned int offsets[8];
   const int16_t _ALIGNED masks[8];
-  const char header_mask;
-  const char header;
+  const unsigned char header_mask;
+  const unsigned char header;
 } Pack;
 
 #define PACK_COUNT 3


### PR DESCRIPTION
maybe use uint8_t instead?

i don't know what `Pack` is for but i know that 0xc0 and 0x80 do not qualify as chars.
